### PR TITLE
Add IM array after set peaks in mzml convert script #31

### DIFF
--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -232,7 +232,7 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width)
     sframe = pyopenms.MSSpectrum()
     sframe.setMSLevel(mslevel)
     sframe.setRT(rtime)
-    sframe.setFloatDataArrays([fda])
+
     p = pyopenms.Precursor()
 
     if mslevel == 2:
@@ -241,6 +241,7 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width)
         p.setIsolationWindowLowerOffset(width / 2.0)
     sframe.setPrecursors([p])
     sframe.set_peaks( (mz, intens) )
+    sframe.setFloatDataArrays([fda])
     sframe.sortByPosition()
 
     return sframe


### PR DESCRIPTION
Add ion mobility array to each spectrum after calling `set_peaks`, to avoid the clear action in `set_peaks` method, which would clean all defined arrays in one spectrum. Related to issue #31