### PR TITLE
Feature: Record IM windows

### DIFF
--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -254,8 +254,8 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
 
     sframe.setPrecursors([p])
     sframe.set_peaks( (mz, intens) )
-    sframe.sortByPosition()
     sframe.setFloatDataArrays([fda])
+    sframe.sortByPosition()
 
     return sframe
 

--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -238,7 +238,6 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
     for k, val in enumerate(ims):
         fda[k] = val
 
-
     sframe = pyopenms.MSSpectrum()
     sframe.setMSLevel(mslevel)
     sframe.setRT(rtime)
@@ -255,7 +254,7 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
 
     sframe.setPrecursors([p])
     sframe.set_peaks( (mz, intens) )
-    #sframe.sortByPosition() ### This line screws up the IM mapping
+    sframe.sortByPosition()
     sframe.setFloatDataArrays([fda])
 
     return sframe
@@ -270,13 +269,11 @@ def get_consumer(output_fname):
         try:
             opt = consumer.getOptions()
             diapysef.util.setCompressionOptions(opt)
-
             consumer.setOptions(opt)
         except Exception as e:
             print(e)
             print("Your version of pyOpenMS does not support any compression, your files may get rather large")
             pass
-
 
     elif output_fname.lower().endswith("sqmass"):
         consumer = pyopenms.MSDataSqlConsumer(output_fname)
@@ -287,8 +284,6 @@ def get_consumer(output_fname):
     return consumer
 
 def main():
-
-    print("JOSH INJECTION!!!")
 
     parser = argparse.ArgumentParser(description ="Conversion program to convert a Bruker raw data file from a timsTOF Pro instrument into a single mzML.")
     parser.add_argument("-a", "--analysis_dir",
@@ -361,17 +356,12 @@ def main():
     N = row[0]
     print("Analysis has {0} frames.".format(N))
 
-
-    print('getting consumer ...')
-
     consumer = get_consumer(output_fname)
 
     if merge_scans != -1:
-        print("getting merge consumer")
         consumer = diapysef.merge_consumer.MergeConsumer(consumer, merge_scans)
 
     if overlap_scans > 1:
-        print('getting overlap consumer')
         
         # For overlapping scans, we need to create N different consumers (N files on disk) 
         # with different file names which will then contain the overlapped spectra 

--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -232,7 +232,6 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width)
     sframe = pyopenms.MSSpectrum()
     sframe.setMSLevel(mslevel)
     sframe.setRT(rtime)
-    sframe.setFloatDataArrays([fda])
     p = pyopenms.Precursor()
 
     if mslevel == 2:
@@ -242,6 +241,7 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width)
     sframe.setPrecursors([p])
     sframe.set_peaks( (mz, intens) )
     sframe.sortByPosition()
+    sframe.setFloatDataArrays([fda])
 
     return sframe
 

--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -85,7 +85,7 @@ def store_frame(frame_id, td, conn, exp, verbose=False, compressFrame=True, keep
         scan_start = int(tmp[2])
         scan_end = int(tmp[3])
         next_scan_switch = scan_end
-        scanBoundariesk0 = td.scanNumberToOneOverK0(frame_id, np.array([scan_end, scan_start]) #spectrum 1/k0 boundaries for the first swath in the frame
+        scanBoundariesk0 = td.scanNumToOneOverK0(frame_id, np.array([scan_end, scan_start])) #spectrum 1/k0 boundaries for the first swath in the frame
         # Check if we already are in the new scan (if there is no
         # gap between scans, happens for diaPASEF):
         if next_scan_switch == num_scans:
@@ -102,7 +102,7 @@ def store_frame(frame_id, td, conn, exp, verbose=False, compressFrame=True, keep
         scan_start = int(tmp[2])
         scan_end = int(tmp[3])
         next_scan_switch = scan_end
-        scanBoundariesk0 = td.scanNumberToOneOverK0(frame_id, np.array([scan_end, scan_start])
+        scanBoundariesk0 = td.scanNumToOneOverK0(frame_id, np.array([scan_end, scan_start]))
         # Check if we already are in the new scan (if there is no
         # gap between scans, happens for diaPASEF):
         if next_scan_switch == num_scans:
@@ -112,11 +112,12 @@ def store_frame(frame_id, td, conn, exp, verbose=False, compressFrame=True, keep
         mslevel = 2
     else:
         # MS1 
-        q = conn.execute("select scanNumBegin, scanNumEnd from Frame where Id={0}".format(frame_id))
+        q = conn.execute("select NumScans from Frames where Id={0}".format(frame_id))
         tmp = q.fetchone()
-        scan_start = int(tmp[0])
-        scan_end = int(tmp[1])
-        scanBoundariesk0 = td.scanNumberToOneOverK0(frame_id, np.array([scan_end, scan_start]) #1/k0 boundaries for ms1 spectrum 
+        scan_start = 0
+        scan_end = int(tmp[0])
+        scanBoundariesk0 = td.scanNumToOneOverK0(frame_id, np.array([scan_end, scan_start])) #1/k0 boundaries for ms1 spectrum 
+        print(scanBoundariesk0[1])
 
     if verbose:
         print("Frame", frame_id, "mslevel", mslevel, msms, "contains nr scans:", num_scans, "and nr pasef scans", len(scandata) if scandata else -1)

--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -238,6 +238,7 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
     for k, val in enumerate(ims):
         fda[k] = val
 
+
     sframe = pyopenms.MSSpectrum()
     sframe.setMSLevel(mslevel)
     sframe.setRT(rtime)
@@ -254,7 +255,7 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
 
     sframe.setPrecursors([p])
     sframe.set_peaks( (mz, intens) )
-    sframe.sortByPosition()
+    #sframe.sortByPosition() ### This line screws up the IM mapping
     sframe.setFloatDataArrays([fda])
 
     return sframe
@@ -269,11 +270,13 @@ def get_consumer(output_fname):
         try:
             opt = consumer.getOptions()
             diapysef.util.setCompressionOptions(opt)
+
             consumer.setOptions(opt)
         except Exception as e:
             print(e)
             print("Your version of pyOpenMS does not support any compression, your files may get rather large")
             pass
+
 
     elif output_fname.lower().endswith("sqmass"):
         consumer = pyopenms.MSDataSqlConsumer(output_fname)
@@ -284,6 +287,8 @@ def get_consumer(output_fname):
     return consumer
 
 def main():
+
+    print("JOSH INJECTION!!!")
 
     parser = argparse.ArgumentParser(description ="Conversion program to convert a Bruker raw data file from a timsTOF Pro instrument into a single mzML.")
     parser.add_argument("-a", "--analysis_dir",
@@ -356,12 +361,17 @@ def main():
     N = row[0]
     print("Analysis has {0} frames.".format(N))
 
+
+    print('getting consumer ...')
+
     consumer = get_consumer(output_fname)
 
     if merge_scans != -1:
+        print("getting merge consumer")
         consumer = diapysef.merge_consumer.MergeConsumer(consumer, merge_scans)
 
     if overlap_scans > 1:
+        print('getting overlap consumer')
         
         # For overlapping scans, we need to create N different consumers (N files on disk) 
         # with different file names which will then contain the overlapped spectra 

--- a/src/diapysef/scripts/convertTDFtoMzML.py
+++ b/src/diapysef/scripts/convertTDFtoMzML.py
@@ -232,6 +232,13 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
     intens = np.concatenate(allint)
     ims = np.concatenate(allim)
 
+    fda = pyopenms.FloatDataArray()
+    fda.setName("Ion Mobility")
+    fda.resize(len(mz))
+    for k, val in enumerate(ims):
+        fda[k] = val
+
+
     sframe = pyopenms.MSSpectrum()
     sframe.setMSLevel(mslevel)
     sframe.setRT(rtime)
@@ -246,27 +253,9 @@ def handle_compressed_frame(allmz, allint, allim, mslevel, rtime, center, width,
     sframe.setMetaValue('ion mobility lower limit', scanBoundariesk0[0])
     sframe.setMetaValue('ion mobility upper limit', scanBoundariesk0[1])
 
-
-    ## sort the arrays by ascending m/z with numpy, ensure that the mapping between m/z intens and IM is maintained
-    mzInds = mz.argsort()
-    sorted_mz = mz[mzInds]
-    sorted_intens = intens[mzInds]
-    sorted_ims = ims[mzInds]
-
     sframe.setPrecursors([p])
-
-    #store peaks
-    sframe.set_peaks( (sorted_mz, sorted_intens) )
-    #sframe.sortByPosition() ### This line screws up the IM mapping, however without this line do not have sorting so have to sort, will use np
-
-    # store ims data
-    sorted_ims.astype(np.float32, casting='unsafe')
-    fda = pyopenms.FloatDataArray()
-    fda.setName("Ion Mobility")
-    fda.resize(len(mz))
-    for k, val in enumerate(sorted_ims):
-        fda[k] = val
-
+    sframe.set_peaks( (mz, intens) )
+    #sframe.sortByPosition() ### This line screws up the IM mapping
     sframe.setFloatDataArrays([fda])
 
     return sframe


### PR DESCRIPTION
Adds 2 new tags to to spectra associated with the IM start and end windows.

These tags are useful for distinguishing SWATHs that overlap in m/z and not in IM. 

Also fixes a few bugs that occur when processing with pyopenms_2.7 of the ion mobility array being sorted (not associated with the m/z value that it appears to be) 
